### PR TITLE
fix: invalid value for `grammars.0.name`

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,7 +1,8 @@
 {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
   "grammars": [
     {
-      "name": "ql-dbscheme",
+      "name": "ql_dbscheme",
       "camelcase": "QlDbscheme",
       "scope": "source.dbscheme",
       "path": ".",


### PR DESCRIPTION
`name` is not allowed to contain `-`'s, see
<https://github.com/tree-sitter/tree-sitter/blob/v0.26.5/docs/src/assets/schemas/config.schema.json#L13-L17>.

Alternatively, would it be better to relax the regex upstream?